### PR TITLE
[feat]: [CI-12621]: Update drone-buildx version for DLC Savings

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.20
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.7.1
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.3.1
-	github.com/drone-plugins/drone-buildx v1.0.3
+	github.com/drone-plugins/drone-buildx v1.1.7
 	github.com/joho/godotenv v1.5.1
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.9.3
@@ -16,7 +16,7 @@ require (
 	github.com/AzureAD/microsoft-authentication-library-for-go v1.1.1 // indirect
 	github.com/coreos/go-semver v0.3.0 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.2 // indirect
-	github.com/drone-plugins/drone-plugin-lib v0.4.1 // indirect
+	github.com/drone-plugins/drone-plugin-lib v0.4.2 // indirect
 	github.com/drone/drone-go v1.7.1 // indirect
 	github.com/golang-jwt/jwt/v5 v5.0.0 // indirect
 	github.com/google/uuid v1.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -17,10 +17,10 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dnaeon/go-vcr v1.2.0 h1:zHCHvJYTMh1N7xnV7zf1m1GPBF9Ad0Jk/whtQ1663qI=
-github.com/drone-plugins/drone-buildx v1.0.3 h1:xaKX5yA0oUKM35EFnlAmHcrOKg9cmSJPKkdj3AMKyNo=
-github.com/drone-plugins/drone-buildx v1.0.3/go.mod h1:z4BaR8J5oF/yly5VPW0PU61XOmrqsZvb5kdarmmSmho=
-github.com/drone-plugins/drone-plugin-lib v0.4.1 h1:47rZlmcMpr1hSp+6Gl+1Z4t+efi/gMQU3lxukC1Yg64=
-github.com/drone-plugins/drone-plugin-lib v0.4.1/go.mod h1:KwCu92jFjHV3xv2hu5Qg/8zBNvGwbhoJDQw/EwnTvoM=
+github.com/drone-plugins/drone-buildx v1.1.7 h1:v++Lb1xJ5pAyN/Mo+NZFtuDLvyWRdGM+LgzuSsArHqU=
+github.com/drone-plugins/drone-buildx v1.1.7/go.mod h1:vof8lA/q9NCcKPV4HSipz30+Du4o10wIcmp+tOlX4yI=
+github.com/drone-plugins/drone-plugin-lib v0.4.2 h1:EiJ3Kco6ypP5noBQqVt1bBbuO1eUAumtPvLTX/NVAYg=
+github.com/drone-plugins/drone-plugin-lib v0.4.2/go.mod h1:KwCu92jFjHV3xv2hu5Qg/8zBNvGwbhoJDQw/EwnTvoM=
 github.com/drone/drone-go v1.7.1 h1:ZX+3Rs8YHUSUQ5mkuMLmm1zr1ttiiE2YGNxF3AnyDKw=
 github.com/drone/drone-go v1.7.1/go.mod h1:fxCf9jAnXDZV1yDr0ckTuWd1intvcQwfJmTRpTZ1mXg=
 github.com/golang-jwt/jwt/v5 v5.0.0 h1:1n1XNM9hk7O9mnQoNBGolZvzebBQ7p93ULHRc28XJUE=


### PR DESCRIPTION
Cache metrics being successfully written, parsed and uploaded to ti-service

FULL RUN
<img width="1728" alt="Screenshot 2024-06-05 at 11 46 58 AM" src="https://github.com/drone-plugins/drone-buildx-acr/assets/114451080/9255740e-df56-4861-b927-50397d150a3f">
<img width="1728" alt="Screenshot 2024-06-05 at 11 47 04 AM" src="https://github.com/drone-plugins/drone-buildx-acr/assets/114451080/9630290d-a56a-43b2-aa1d-82e6c32b5794">

OPTIMIZED RUN
<img width="1728" alt="Screenshot 2024-06-05 at 11 47 48 AM" src="https://github.com/drone-plugins/drone-buildx-acr/assets/114451080/04cc0bbf-3a2a-41a1-a0b9-cf6a7ce73781">
<img width="1728" alt="Screenshot 2024-06-05 at 11 47 58 AM" src="https://github.com/drone-plugins/drone-buildx-acr/assets/114451080/48bdaa68-18da-4fef-9fae-902cbf120a56">


TI Service Savings Table Entries for both runs
<img width="1728" alt="Screenshot 2024-06-05 at 11 48 31 AM" src="https://github.com/drone-plugins/drone-buildx-acr/assets/114451080/288e8080-923a-4c63-ad53-e64625b59925">
