### PR TITLE
build and push image tags to plugins/drone-buildx-acr repository

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -70,7 +70,7 @@ depends_on:
 
 trigger:
   ref:
-    - refs/heads/master
+    - refs/heads/main
     - refs/tags/*
     - "refs/pull/**"
 
@@ -112,7 +112,7 @@ depends_on:
 
 trigger:
   ref:
-    - refs/heads/master
+    - refs/heads/main
     - refs/tags/*
     - "refs/pull/**"
 
@@ -167,7 +167,7 @@ steps:
 
 trigger:
   ref:
-    - refs/heads/master
+    - refs/heads/main
     - "refs/tags/**"
     - "refs/pull/**"
 
@@ -227,7 +227,7 @@ steps:
 
 trigger:
   ref:
-    - refs/heads/master
+    - refs/heads/main
     - "refs/tags/**"
     - "refs/pull/**"
 
@@ -259,7 +259,7 @@ steps:
 
 trigger:
   ref:
-    - refs/heads/master
+    - refs/heads/main
     - "refs/tags/**"
 
 depends_on:

--- a/.drone.yml
+++ b/.drone.yml
@@ -32,6 +32,242 @@ trigger:
     - "refs/pull/**"
 
 ---
+kind: pipeline
+type: vm
+name: windows-1809
+
+pool:
+  use: windows
+
+platform:
+  os: windows
+  arch: amd64
+
+steps:
+  - name: go build
+    image: golang:1.19
+    environment:
+      CGO_ENABLED: 0
+    commands:
+      - go build -o release/windows/amd64/buildx-acr.exe ./cmd/drone-buildx-acr
+  - name: build acr plugin
+    image: plugins/docker:20.17.4-windows-1809-amd64
+    settings:
+      dockerfile: docker/acr/Dockerfile.windows.amd64.1809
+      repo: plugins/buildx-acr
+      username:
+        from_secret: docker_username
+      password:
+        from_secret: docker_password
+      auto_tag: true
+      auto_tag_suffix: windows-1809-amd64
+      purge: false
+    when:
+      event: [push, tag]
+
+depends_on:
+  - testing
+
+trigger:
+  ref:
+    - refs/heads/master
+    - refs/tags/*
+    - "refs/pull/**"
+
+---
+kind: pipeline
+type: vm
+name: windows-ltsc2022
+
+pool:
+  use: windows-2022
+
+platform:
+  os: windows
+
+steps:
+  - name: go build
+    image: golang:1.19
+    environment:
+      CGO_ENABLED: 0
+    commands:
+      - go build -o release/windows/amd64/buildx-acr.exe ./cmd/drone-buildx-acr
+  - name: build acr plugin
+    image: plugins/docker
+    settings:
+      dockerfile: docker/acr/Dockerfile.windows.amd64.ltsc2022
+      repo: plugins/buildx-acr
+      username:
+        from_secret: docker_username
+      password:
+        from_secret: docker_password
+      auto_tag: true
+      auto_tag_suffix: windows-ltsc2022-amd64
+      purge: false
+    when:
+      event: [push, tag]
+
+depends_on:
+  - testing
+
+trigger:
+  ref:
+    - refs/heads/master
+    - refs/tags/*
+    - "refs/pull/**"
+
+---
+kind: pipeline
+name: linux-amd64-acr
+type: vm
+
+pool:
+  use: ubuntu
+
+platform:
+  os: linux
+  arch: amd64
+
+steps:
+  - name: build-push
+    image: golang:1.19
+    commands:
+      - 'go build -v -ldflags "-X main.build=${DRONE_BUILD_NUMBER}" -a -tags netgo -o release/linux/amd64/buildx-acr ./cmd/drone-buildx-acr'
+    environment:
+      CGO_ENABLED: 0
+    when:
+      event:
+        exclude:
+          - tag
+  - name: build-tag
+    image: golang:1.19
+    commands:
+      - 'go build -v -ldflags "-X main.version=${DRONE_TAG##v} -X main.build=${DRONE_BUILD_NUMBER}" -a -tags netgo -o release/linux/amd64/buildx-acr ./cmd/drone-buildx-acr'
+    environment:
+      CGO_ENABLED: 0
+    when:
+      event:
+        - tag
+  - name: publish
+    image: plugins/docker:18
+    settings:
+      auto_tag: true
+      auto_tag_suffix: linux-amd64
+      daemon_off: false
+      dockerfile: docker/acr/Dockerfile.linux.amd64
+      password:
+        from_secret: docker_password
+      repo: plugins/buildx-acr
+      username:
+        from_secret: docker_username
+    when:
+      event:
+        exclude:
+          - pull_request
+
+trigger:
+  ref:
+    - refs/heads/master
+    - "refs/tags/**"
+    - "refs/pull/**"
+
+depends_on:
+  - testing
+
+---
+kind: pipeline
+name: linux-arm64-acr
+type: vm
+
+pool:
+  use: ubuntu_arm64
+
+platform:
+  os: linux
+  arch: arm64
+
+steps:
+  - name: build-push
+    image: golang:1.19
+    commands:
+      - 'go build -v -ldflags "-X main.build=${DRONE_BUILD_NUMBER}" -a -tags netgo -o release/linux/arm64/buildx-acr ./cmd/drone-buildx-acr'
+    environment:
+      CGO_ENABLED: 0
+    when:
+      event:
+        exclude:
+          - tag
+
+  - name: build-tag
+    image: golang:1.19
+    commands:
+      - 'go build -v -ldflags "-X main.version=${DRONE_TAG##v} -X main.build=${DRONE_BUILD_NUMBER}" -a -tags netgo -o release/linux/arm64/buildx-acr ./cmd/drone-buildx-acr'
+    environment:
+      CGO_ENABLED: 0
+    when:
+      event:
+        - tag
+
+  - name: publish
+    image: plugins/docker:18
+    settings:
+      auto_tag: true
+      auto_tag_suffix: linux-arm64
+      daemon_off: false
+      dockerfile: docker/acr/Dockerfile.linux.arm64
+      password:
+        from_secret: docker_password
+      repo: plugins/buildx-acr
+      username:
+        from_secret: docker_username
+    when:
+      event:
+        exclude:
+          - pull_request
+
+trigger:
+  ref:
+    - refs/heads/master
+    - "refs/tags/**"
+    - "refs/pull/**"
+
+depends_on:
+  - testing
+
+---
+kind: pipeline
+name: notifications-acr
+type: vm
+
+pool:
+  use: ubuntu
+
+platform:
+  os: linux
+  arch: amd64
+
+steps:
+  - name: manifest
+    image: plugins/manifest
+    settings:
+      ignore_missing: true
+      password:
+        from_secret: docker_password
+      spec: docker/acr/manifest.tmpl
+      username:
+        from_secret: docker_username
+
+trigger:
+  ref:
+    - refs/heads/master
+    - "refs/tags/**"
+
+depends_on:
+  - windows-1809
+  - windows-ltsc2022
+  - linux-amd64-acr
+  - linux-arm64-acr
+---
 
 kind: pipeline
 name: release-binaries

--- a/docker/acr/Dockerfile.linux.amd64
+++ b/docker/acr/Dockerfile.linux.amd64
@@ -1,0 +1,4 @@
+FROM plugins/buildx:linux-amd64
+
+ADD release/linux/amd64/buildx-acr /bin/
+ENTRYPOINT ["/usr/local/bin/dockerd-entrypoint.sh", "/bin/buildx-acr"]

--- a/docker/acr/Dockerfile.linux.arm64
+++ b/docker/acr/Dockerfile.linux.arm64
@@ -1,0 +1,4 @@
+FROM plugins/buildx:linux-arm64
+
+ADD release/linux/arm64/buildx-acr /bin/
+ENTRYPOINT ["/usr/local/bin/dockerd-entrypoint.sh", "/bin/buildx-acr"]

--- a/docker/acr/Dockerfile.windows.amd64.1809
+++ b/docker/acr/Dockerfile.windows.amd64.1809
@@ -1,0 +1,10 @@
+# escape=`
+FROM plugins/buildx:windows-1809-amd64
+
+LABEL maintainer="Drone.IO Community <drone-dev@googlegroups.com>" `
+  org.label-schema.name="Drone ACR" `
+  org.label-schema.vendor="Drone.IO Community" `
+  org.label-schema.schema-version="1.0"
+
+ADD release/windows/amd64/buildx-acr.exe C:/bin/buildx-acr.exe
+ENTRYPOINT [ "C:\\bin\\buildx-acr.exe" ]

--- a/docker/acr/Dockerfile.windows.amd64.ltsc2022
+++ b/docker/acr/Dockerfile.windows.amd64.ltsc2022
@@ -1,0 +1,10 @@
+# escape=`
+FROM plugins/buildx:windows-ltsc2022-amd64
+
+LABEL maintainer="Drone.IO Community <drone-dev@googlegroups.com>" `
+  org.label-schema.name="Drone ACR" `
+  org.label-schema.vendor="Drone.IO Community" `
+  org.label-schema.schema-version="1.0"
+
+ADD release/windows/amd64/buildx-acr.exe C:/bin/buildx-acr.exe
+ENTRYPOINT [ "C:\\bin\\buildx-acr.exe" ]

--- a/docker/acr/manifest.tmpl
+++ b/docker/acr/manifest.tmpl
@@ -1,0 +1,31 @@
+image: plugins/buildx-acr:{{#if build.tag}}{{trimPrefix "v" build.tag}}{{else}}latest{{/if}}
+{{#if build.tags}}
+tags:
+{{#each build.tags}}
+  - {{this}}
+{{/each}}
+{{/if}}
+manifests:
+  -
+    image: plugins/buildx-acr:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}linux-amd64
+    platform:
+      architecture: amd64
+      os: linux
+  -
+    image: plugins/buildx-acr:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}linux-arm64
+    platform:
+      architecture: arm64
+      os: linux
+      variant: v8
+  -
+    image: plugins/buildx-acr:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}windows-1809-amd64
+    platform:
+      architecture: amd64
+      os: windows
+      version: 1809
+  -
+    image: plugins/buildx-acr:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}windows-ltsc2022-amd64
+    platform:
+      architecture: amd64
+      os: windows
+      version: ltsc2022


### PR DESCRIPTION
Adding the support to build and push docker image for the respective plugins in its own repo, all of which was originally handled in drone-buildx plugin.
Creating and uploading the binary executables for all linux-amd, linux-arm, windows.