### PR TITLE
feat: [CI-17135]: Update dependent buildx to v1.2.3 that includes push-only support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ toolchain go1.22.0
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.7.1
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.3.1
-	github.com/drone-plugins/drone-buildx v1.2.1
+	github.com/drone-plugins/drone-buildx v1.2.3-debug
 	github.com/joho/godotenv v1.5.1
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.9.3

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ toolchain go1.22.0
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.7.1
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.3.1
-	github.com/drone-plugins/drone-buildx v1.2.3-debug
+	github.com/drone-plugins/drone-buildx v1.2.3
 	github.com/joho/godotenv v1.5.1
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.9.3

--- a/go.sum
+++ b/go.sum
@@ -18,8 +18,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dnaeon/go-vcr v1.2.0 h1:zHCHvJYTMh1N7xnV7zf1m1GPBF9Ad0Jk/whtQ1663qI=
 github.com/dnaeon/go-vcr v1.2.0/go.mod h1:R4UdLID7HZT3taECzJs4YgbbH6PIGXB6W/sc5OLb6RQ=
-github.com/drone-plugins/drone-buildx v1.2.3-debug h1:j4kHsIdL49B67XrXW7+vmVOvLB1peL63id2n11nIDR8=
-github.com/drone-plugins/drone-buildx v1.2.3-debug/go.mod h1:RvpdpL5Ho1rY7kG2td+0Mcle7A81ozBEl6jc1F6m6a8=
+github.com/drone-plugins/drone-buildx v1.2.3 h1:DLmWPzQvwa7DBhczjzrfYieQLgvAszHHS0DkkeiJJns=
+github.com/drone-plugins/drone-buildx v1.2.3/go.mod h1:RvpdpL5Ho1rY7kG2td+0Mcle7A81ozBEl6jc1F6m6a8=
 github.com/drone-plugins/drone-plugin-lib v0.4.2 h1:EiJ3Kco6ypP5noBQqVt1bBbuO1eUAumtPvLTX/NVAYg=
 github.com/drone-plugins/drone-plugin-lib v0.4.2/go.mod h1:KwCu92jFjHV3xv2hu5Qg/8zBNvGwbhoJDQw/EwnTvoM=
 github.com/drone/drone-go v1.7.1 h1:ZX+3Rs8YHUSUQ5mkuMLmm1zr1ttiiE2YGNxF3AnyDKw=

--- a/go.sum
+++ b/go.sum
@@ -18,8 +18,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dnaeon/go-vcr v1.2.0 h1:zHCHvJYTMh1N7xnV7zf1m1GPBF9Ad0Jk/whtQ1663qI=
 github.com/dnaeon/go-vcr v1.2.0/go.mod h1:R4UdLID7HZT3taECzJs4YgbbH6PIGXB6W/sc5OLb6RQ=
-github.com/drone-plugins/drone-buildx v1.2.1 h1:a7eN1oy4u8PqeFPiG2gDhRfKWdw8WvkwRYLD/tvnGPw=
-github.com/drone-plugins/drone-buildx v1.2.1/go.mod h1:RvpdpL5Ho1rY7kG2td+0Mcle7A81ozBEl6jc1F6m6a8=
+github.com/drone-plugins/drone-buildx v1.2.3-debug h1:j4kHsIdL49B67XrXW7+vmVOvLB1peL63id2n11nIDR8=
+github.com/drone-plugins/drone-buildx v1.2.3-debug/go.mod h1:RvpdpL5Ho1rY7kG2td+0Mcle7A81ozBEl6jc1F6m6a8=
 github.com/drone-plugins/drone-plugin-lib v0.4.2 h1:EiJ3Kco6ypP5noBQqVt1bBbuO1eUAumtPvLTX/NVAYg=
 github.com/drone-plugins/drone-plugin-lib v0.4.2/go.mod h1:KwCu92jFjHV3xv2hu5Qg/8zBNvGwbhoJDQw/EwnTvoM=
 github.com/drone/drone-go v1.7.1 h1:ZX+3Rs8YHUSUQ5mkuMLmm1zr1ttiiE2YGNxF3AnyDKw=


### PR DESCRIPTION
https://github.com/drone-plugins/drone-buildx/pull/62

Test execution [LINK](https://app.harness.io/ng/account/fjf_VfuITK2bBrMLg5xV7g/module/cd/orgs/default/projects/GlobalCorp/pipelines/OPCI17135buildxacr/deployments/UdgqZpK6RdCQtYQFoGqskQ/pipeline?storeType=INLINE&step=kLgxGQeFSWOcCKaZjyMRIg&stage=llDrfS2rSM6crdbFhena1Q&childStage=&stageExecId=)