### PR TITLE
feat: [CI-22341]: bump drone-buildx to v1.3.18

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.26
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.21.0
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.13.1
-	github.com/drone-plugins/drone-buildx v1.3.17
+	github.com/drone-plugins/drone-buildx v1.3.18
 	github.com/joho/godotenv v1.5.1
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.9.4

--- a/go.sum
+++ b/go.sum
@@ -19,8 +19,8 @@ github.com/cpuguy83/go-md2man/v2 v2.0.7/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6N
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/drone-plugins/drone-buildx v1.3.17 h1:KXWovDJ59ZaeHyZ3mrqSxM3wQ5X5ltSJTMGQ7Gaeej8=
-github.com/drone-plugins/drone-buildx v1.3.17/go.mod h1:MbPN45ES9bvQIO8NP7liagrZy5y+Oz0GLNgp6Se6Kf8=
+github.com/drone-plugins/drone-buildx v1.3.18 h1:rB2ITc3Nu9MyVDXmo+LLShzcuQXQyebFlDFbKquMDDc=
+github.com/drone-plugins/drone-buildx v1.3.18/go.mod h1:MbPN45ES9bvQIO8NP7liagrZy5y+Oz0GLNgp6Se6Kf8=
 github.com/drone-plugins/drone-plugin-lib v0.4.2 h1:EiJ3Kco6ypP5noBQqVt1bBbuO1eUAumtPvLTX/NVAYg=
 github.com/drone-plugins/drone-plugin-lib v0.4.2/go.mod h1:KwCu92jFjHV3xv2hu5Qg/8zBNvGwbhoJDQw/EwnTvoM=
 github.com/drone/drone-go v1.7.1 h1:ZX+3Rs8YHUSUQ5mkuMLmm1zr1ttiiE2YGNxF3AnyDKw=


### PR DESCRIPTION
## Summary
- Bumps `github.com/drone-plugins/drone-buildx` from `v1.3.17` → `v1.3.18`
- Regenerated `go.sum` via `go mod tidy`

## Test plan
- [x] `go build ./...` passes locally
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)