### PR TITLE
feat:[CI-23139]: Bumping the buildx version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.26
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.21.0
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.13.1
-	github.com/drone-plugins/drone-buildx v1.3.19
+	github.com/drone-plugins/drone-buildx v1.3.20
 	github.com/joho/godotenv v1.5.1
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.9.4

--- a/go.sum
+++ b/go.sum
@@ -19,8 +19,8 @@ github.com/cpuguy83/go-md2man/v2 v2.0.7/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6N
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/drone-plugins/drone-buildx v1.3.19 h1:zaQltw2XSd99jWPs/caRqzU1HQ09Zu0mpqQ7Qqw93xw=
-github.com/drone-plugins/drone-buildx v1.3.19/go.mod h1:MbPN45ES9bvQIO8NP7liagrZy5y+Oz0GLNgp6Se6Kf8=
+github.com/drone-plugins/drone-buildx v1.3.20 h1:Oe9Jn/fyBS7YKRlvSnEGUS5ouN6M+Yhwjf75Acap2sw=
+github.com/drone-plugins/drone-buildx v1.3.20/go.mod h1:MbPN45ES9bvQIO8NP7liagrZy5y+Oz0GLNgp6Se6Kf8=
 github.com/drone-plugins/drone-plugin-lib v0.4.2 h1:EiJ3Kco6ypP5noBQqVt1bBbuO1eUAumtPvLTX/NVAYg=
 github.com/drone-plugins/drone-plugin-lib v0.4.2/go.mod h1:KwCu92jFjHV3xv2hu5Qg/8zBNvGwbhoJDQw/EwnTvoM=
 github.com/drone/drone-go v1.7.1 h1:ZX+3Rs8YHUSUQ5mkuMLmm1zr1ttiiE2YGNxF3AnyDKw=


### PR DESCRIPTION
- Bumping the drone-buildx version to support the DLC with the Azure backend
- Build pipeline: https://app.harness.io/ng/account/gCoPSwHxS7ipOgx2iA9tOQ/module/ci/orgs/default/projects/Drone_Plugins/pipelines/dronebuildxharness/deployments/YQ-HRwTDTRCFjcCGPxE2RQ/pipeline?connectorRef=GitHub_Drone_Plugins_Org&repoName=drone-buildx&storeType=REMOTE&step=tM-9oPlWTm6Wf3D_Jomy8Q&stage=ueslzrD0TU6lmVe3OcIBGg&childStage=&stageExecId=ueslzrD0TU6lmVe3OcIBGg