### PR TITLE
feat: [CI-23661]: windows 2025 support

### DIFF
--- a/docker/acr/Dockerfile.windows.amd64.ltsc2025
+++ b/docker/acr/Dockerfile.windows.amd64.ltsc2025
@@ -1,0 +1,10 @@
+# escape=`
+FROM plugins/buildx:windows-ltsc2025-amd64
+
+LABEL maintainer="Drone.IO Community <drone-dev@googlegroups.com>" `
+  org.label-schema.name="Drone ACR" `
+  org.label-schema.vendor="Drone.IO Community" `
+  org.label-schema.schema-version="1.0"
+
+ADD release/windows/amd64/buildx-acr.exe C:/bin/buildx-acr.exe
+ENTRYPOINT [ "C:\\bin\\buildx-acr.exe" ]

--- a/docker/acr/manifest.tmpl
+++ b/docker/acr/manifest.tmpl
@@ -29,3 +29,9 @@ manifests:
       architecture: amd64
       os: windows
       version: ltsc2022
+  -
+    image: plugins/buildx-acr:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}windows-ltsc2025-amd64
+    platform:
+      architecture: amd64
+      os: windows
+      version: ltsc2025


### PR DESCRIPTION
This pull request adds support for Windows LTSC 2025 to the ACR (Azure Container Registry) buildx plugin. The main updates include a new Dockerfile for the LTSC 2025 platform and an updated manifest to publish this new image variant.

**Windows LTSC 2025 support:**

* Added a new Dockerfile `Dockerfile.windows.amd64.ltsc2025` for building the ACR plugin image targeting Windows LTSC 2025 and the amd64 architecture.
* Updated `manifest.tmpl` to include the new `windows-ltsc2025-amd64` image variant for multi-platform publishing.