### PR TITLE
feat: [CI-23744]: bump drone-buildx to v1.3.23 for proxy and CA support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.26
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.21.0
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.13.1
-	github.com/drone-plugins/drone-buildx v1.3.20
+	github.com/drone-plugins/drone-buildx v1.3.23
 	github.com/joho/godotenv v1.5.1
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.9.4

--- a/go.sum
+++ b/go.sum
@@ -19,8 +19,8 @@ github.com/cpuguy83/go-md2man/v2 v2.0.7/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6N
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/drone-plugins/drone-buildx v1.3.20 h1:Oe9Jn/fyBS7YKRlvSnEGUS5ouN6M+Yhwjf75Acap2sw=
-github.com/drone-plugins/drone-buildx v1.3.20/go.mod h1:MbPN45ES9bvQIO8NP7liagrZy5y+Oz0GLNgp6Se6Kf8=
+github.com/drone-plugins/drone-buildx v1.3.23 h1:ntXvbatGFU8oIuQU2n6kARn93EfrS2jVKs9MDBvYaDc=
+github.com/drone-plugins/drone-buildx v1.3.23/go.mod h1:MbPN45ES9bvQIO8NP7liagrZy5y+Oz0GLNgp6Se6Kf8=
 github.com/drone-plugins/drone-plugin-lib v0.4.2 h1:EiJ3Kco6ypP5noBQqVt1bBbuO1eUAumtPvLTX/NVAYg=
 github.com/drone-plugins/drone-plugin-lib v0.4.2/go.mod h1:KwCu92jFjHV3xv2hu5Qg/8zBNvGwbhoJDQw/EwnTvoM=
 github.com/drone/drone-go v1.7.1 h1:ZX+3Rs8YHUSUQ5mkuMLmm1zr1ttiiE2YGNxF3AnyDKw=


### PR DESCRIPTION
## Summary

Bump drone-buildx dependency from v1.3.20 to v1.3.23 to inherit proxy environment variable forwarding and CA certificate trust fixes for BuildKit containers running behind egress proxies.

## Root Cause

The drone-buildx-acr plugin depends on drone-buildx v1.3.20, which does not forward standard proxy environment variables (http_proxy, https_proxy, no_proxy) or HARNESS_CA_PATH to the BuildKit docker-container driver. When Build-and-Push steps run behind the Harness egress proxy with TLS interception, BuildKit containers:

1. Cannot reach external registries (timeout on dial tcp)
2. Reject TLS connections with `x509: certificate signed by unknown authority`

The upstream drone-buildx repository was fixed in [PR #115](https://github.com/drone-plugins/drone-buildx/pull/115) (v1.3.21-v1.3.23), which:
- Added `appendProxyDriverOpts` to forward standard proxy vars to buildx driver-opts with precedence: standard → uppercase → HARNESS_*
- Added `appendHarnessCADriverOpts` to forward HARNESS_CA_PATH and cert content as env vars
- Handles comma-separated no_proxy values via quoting

## Solution

Update go.mod to depend on drone-buildx v1.3.23, which includes all proxy and CA forwarding fixes.

## Changes Made

- `go.mod`: Bumped `github.com/drone-plugins/drone-buildx` from v1.3.20 to v1.3.23
- `go.sum`: Updated checksums for new version

## Testing

- [x] Build succeeds (`go build ./...`)
- [ ] CI pipeline validates integration

## Related Issues/Logs

- JIRA: [CI-23744](https://harness.atlassian.net/browse/CI-23744)
- Upstream drone-buildx fix: https://github.com/drone-plugins/drone-buildx/pull/115
- BuildKit entrypoint wrapper: https://harness0.harness.io/ng/account/l7B_kbSEQD2wjrM7PShm5w/module/code/orgs/PROD/projects/CI/repos/buildkit/pulls/19/conversation
- Customer: HNB (Huntington) egress proxy testing

---
🚢 *Shipped via [Ship](https://github.com/raghavharness/knowledge-base)*

[CI-23744]: https://harness.atlassian.net/browse/CI-23744?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ